### PR TITLE
AL - FIxes for team02 starting issues

### DIFF
--- a/issues/issue00_set_up_deployment_on_heroku.md
+++ b/issues/issue00_set_up_deployment_on_heroku.md
@@ -10,7 +10,6 @@ Set up a team deployments for prod and qa on Heroku
 - [ ] The course instructor (`phtcon@ucsb.edu`) and the mentor listed
       at <https://ucsb-cs156.github.io/s22/info/teams/> is added to
       the heroku  deployment. (Ask for the email they use with
-      Heroku via slack.)
-
-
-
+      Heroku via Slack.)
+- [ ] Repeat the above steps for your team's QA deployment, which follows the same naming convention as the production app except with `-qa` appended to it. For example, <https://s22-5pm-1-team02-qa.herokuapp.com>.
+- [ ] Links to both your team's production and QA Heroku deployments are added to the top of your team's `README.md` file, replacing the `TODO` entry.

--- a/issues/issue02_codecov_token.md
+++ b/issues/issue02_codecov_token.md
@@ -28,4 +28,4 @@ Set up codecov token and codecov badge.
    
    Copy the Markdown for the badge.  
    
-   Put it at the beginning of your README.mdm under the first header. (Make a branch and do a PR for this, even though it may seem like a trivial change. It's good to practice the mechanics here, since you'll need to do them many times in this course.)
+   Put it at the beginning of your README.md under the first header. (Make a branch and do a PR for this, even though it may seem like a trivial change. It's good to practice the mechanics here, since you'll need to do them many times in this course.)

--- a/issues/issue02_codecov_token.md
+++ b/issues/issue02_codecov_token.md
@@ -28,6 +28,4 @@ Set up codecov token and codecov badge.
    
    Copy the Markdown for the badge.  
    
-   Put it in your README.md.  (Make a branch and do a PR for this, even
-   though it may seem like a trivial change.  It's good to practice
-   the mechanics here, since you'll need to do them many times in this course.)
+   Put it at the beginning of your README.mdm under the first header. (Make a branch and do a PR for this, even though it may seem like a trivial change. It's good to practice the mechanics here, since you'll need to do them many times in this course.)

--- a/issues/issue12_add_list_all_and_post_endpoints.md
+++ b/issues/issue12_add_list_all_and_post_endpoints.md
@@ -6,7 +6,7 @@ Create `UCSBDiningCommonsMenuItemController`, add `GET` (index) and `POST` (crea
       in the expected directory.
 - [ ] In `UCSBDiningCommonsMenuItemController.java` there is 
       code for a `GET /api/UCSBDiningCommonsMenuItem/all` endpoint 
-      that returns a JSON list of all subreddits in the database.
+      that returns a JSON list of all `UCSBDiningCommonsMenuItem`s in the database.
       (We sometimes call this an *index* action since it lists all
       items in the database.)
 - [ ] In `UCSBDiningCommonsMenuItemController.java` there is 

--- a/issues/issue22_add_list_all_and_post_endpoints.md
+++ b/issues/issue22_add_list_all_and_post_endpoints.md
@@ -6,7 +6,7 @@ Create `UCSBOrganizationController`, add `GET` (index) and `POST` (create)
       in the expected directory.
 - [ ] In `UCSBOrganizationController.java` there is 
       code for a `GET /api/UCSBOrganization/all` endpoint 
-      that returns a JSON list of all subreddits in the database.
+      that returns a JSON list of all `UCSBOrganization`s in the database.
       (We sometimes call this an *index* action since it lists all
       items in the database.)
 - [ ] In `UCSBOrganizationController.java` there is 

--- a/issues/issue32_add_list_all_and_post_endpoints.md
+++ b/issues/issue32_add_list_all_and_post_endpoints.md
@@ -6,7 +6,7 @@ Create `RecommendationController`, add `GET` (index) and `POST` (create)
       in the expected directory.
 - [ ] In `RecommendationController.java` there is 
       code for a `GET /api/Recommendation/all` endpoint 
-      that returns a JSON list of all subreddits in the database.
+      that returns a JSON list of all `Recommendation`s in the database.
       (We sometimes call this an *index* action since it lists all
       items in the database.)
 - [ ] In `RecommendationController.java` there is 

--- a/issues/issue42_add_list_all_and_post_endpoints.md
+++ b/issues/issue42_add_list_all_and_post_endpoints.md
@@ -6,7 +6,7 @@ Create `MenuItemReviewController`, add `GET` (index) and `POST` (create)
       in the expected directory.
 - [ ] In `MenuItemReviewController.java` there is 
       code for a `GET /api/MenuItemReview/all` endpoint 
-      that returns a JSON list of all subreddits in the database.
+      that returns a JSON list of all `MenuItemReview`s in the database.
       (We sometimes call this an *index* action since it lists all
       items in the database.)
 - [ ] In `MenuItemReviewController.java` there is 

--- a/issues/issue52_add_list_all_and_post_endpoints.md
+++ b/issues/issue52_add_list_all_and_post_endpoints.md
@@ -6,7 +6,7 @@ Create `HelpRequestController`, add `GET` (index) and `POST` (create)
       in the expected directory.
 - [ ] In `HelpRequestController.java` there is 
       code for a `GET /api/HelpRequest/all` endpoint 
-      that returns a JSON list of all subreddits in the database.
+      that returns a JSON list of all `HelpRequest`s in the database.
       (We sometimes call this an *index* action since it lists all
       items in the database.)
 - [ ] In `HelpRequestController.java` there is 

--- a/issues/issue62_add_list_all_and_post_endpoints.md
+++ b/issues/issue62_add_list_all_and_post_endpoints.md
@@ -6,7 +6,7 @@ Create `ArticleController`, add `GET` (index) and `POST` (create)
       in the expected directory.
 - [ ] In `ArticleController.java` there is 
       code for a `GET /api/Article/all` endpoint 
-      that returns a JSON list of all subreddits in the database.
+      that returns a JSON list of all `Article`s in the database.
       (We sometimes call this an *index* action since it lists all
       items in the database.)
 - [ ] In `ArticleController.java` there is 


### PR DESCRIPTION
This PR makes a few changes to the starter stories in team02:

* Codecov badge placement instructions were made more clear - students are now instructed to place it at the top of their `README.md` file under the first heading
* In the `GET` endpoint specification, updated to display the actual entity being retrieved instead of `subreddits`
* In the Heroku setup instructions, two new steps were added
    * The first instructs the team to perform the instructions again, this time for their QA deployment
    * The second instructs the team to add the production and QA deployment links to their team's `README.md` file